### PR TITLE
add support for typescript & es6 import syntax

### DIFF
--- a/express-favicon.d.ts
+++ b/express-favicon.d.ts
@@ -1,0 +1,1 @@
+declare module 'express-favicon';


### PR DESCRIPTION
I was facing importing warning when I used this module as follows:
```
import favicon from 'express-favicon';
```
So I added this file to support for TS & ES6 syntax.
Thanks for your kind attention.